### PR TITLE
Fixes the behavior when terminating the VDR process

### DIFF
--- a/Listener.cpp
+++ b/Listener.cpp
@@ -41,13 +41,17 @@ Listener::Listener(EventHandler *event)
 {
 	this->event = event;
 	thread = new std::thread(&Listener::run, this);
+	threadNativeHandle = thread->native_handle();
+	thread->detach();
 }
 
 Listener::~Listener()
 {
 	if (thread) {
 		cancelThread();
-		thread->join();
+		int r = pthread_cancel(threadNativeHandle);
+		if (r != 0)
+			ERR(std::string{"could not cancel thread: "} + strerror(r));
 		delete thread;
 	}
 }

--- a/Listener.h
+++ b/Listener.h
@@ -59,6 +59,7 @@ private:
 	EventHandler *event;
 	std::vector<int> activeConnections;
 	std::thread *thread;
+	pthread_t threadNativeHandle;
 	network::TcpClient *tcpClientPtr = nullptr;
 	Listener(EventHandler *event);
 	void handleNewCall(bool outgoing, int connId, std::string remoteNumber, std::string localParty, std::string medium);


### PR DESCRIPTION
vdr does not terminate properly when vdr-fritzbox is enabled. This change corrects it.

See also conversation here https://github.com/jowi24/vdr-fritz/issues/2